### PR TITLE
Fix tests for reminder storage

### DIFF
--- a/src/main/java/seedu/address/model/reminder/Date.java
+++ b/src/main/java/seedu/address/model/reminder/Date.java
@@ -54,9 +54,8 @@ public class Date implements Comparable<Date> {
      */
     public boolean isUpcoming() {
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime sevenDaysLater = now.plusDays(7);
 
-        return !value.isBefore(now) && !value.isAfter(sevenDaysLater);
+        return !value.isBefore(now);
     }
 
     /**

--- a/src/main/java/seedu/address/model/reminder/Reminder.java
+++ b/src/main/java/seedu/address/model/reminder/Reminder.java
@@ -101,12 +101,13 @@ public class Reminder {
         Reminder otherReminder = (Reminder) other;
         return person.equals(otherReminder.person)
                 && date.equals(otherReminder.date)
-                && message.equals(otherReminder.message);
+                && message.equals(otherReminder.message)
+                && isCompleted == otherReminder.isCompleted;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(person, date, message);
+        return Objects.hash(person, date, message, isCompleted);
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedReminder.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedReminder.java
@@ -1,0 +1,81 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.Person;
+import seedu.address.model.reminder.Date;
+import seedu.address.model.reminder.Message;
+import seedu.address.model.reminder.Reminder;
+
+/**
+ * Jackson-friendly version of {@link Reminder}.
+ */
+class JsonAdaptedReminder {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Reminder's %s field is missing!";
+
+    private final JsonAdaptedPerson person;
+    private final String date;
+    private final String message;
+    private final boolean isCompleted;
+
+    /**
+     * Constructs a {@code JsonAdaptedReminder} with the given reminder details.
+     */
+    @JsonCreator
+    public JsonAdaptedReminder(@JsonProperty("person") JsonAdaptedPerson person,
+                               @JsonProperty("date") String date,
+                               @JsonProperty("message") String message,
+                               @JsonProperty("isCompleted") boolean isCompleted) {
+        this.person = person;
+        this.date = date;
+        this.message = message;
+        this.isCompleted = isCompleted;
+    }
+
+    /**
+     * Converts a given {@code Reminder} into this class for Jackson use.
+     */
+    public JsonAdaptedReminder(Reminder source) {
+        person = new JsonAdaptedPerson(source.getPerson());
+        date = source.getDate().toString();
+        message = source.getMessage().toString();
+        isCompleted = source.isCompleted();
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted reminder object into the model's {@code Reminder} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted reminder.
+     */
+    public Reminder toModelType() throws IllegalValueException {
+        if (person == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Person.class.getSimpleName()));
+        }
+        final Person modelPerson = person.toModelType();
+
+        if (date == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Date.class.getSimpleName()));
+        }
+        if (!Date.isValidDate(date)) {
+            throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
+        }
+        final Date modelDate = new Date(date);
+
+        if (message == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Message.class.getSimpleName()));
+        }
+        if (!Message.isValidMessage(message)) {
+            throw new IllegalValueException(Message.MESSAGE_CONSTRAINTS);
+        }
+        final Message modelMessage = new Message(message);
+
+        return new Reminder(modelPerson, modelDate, modelMessage, isCompleted);
+    }
+
+}

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -12,6 +12,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
+import seedu.address.model.reminder.Reminder;
 
 /**
  * An Immutable AddressBook that is serializable to JSON format.
@@ -20,15 +21,23 @@ import seedu.address.model.person.Person;
 class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+    public static final String MESSAGE_DUPLICATE_REMINDER = "Reminders list contains duplicate reminder(s).";
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
+    private final List<JsonAdaptedReminder> reminders = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableAddressBook} with the given persons.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons) {
-        this.persons.addAll(persons);
+    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons,
+                                        @JsonProperty("reminders") List<JsonAdaptedReminder> reminders) {
+        if (persons != null) {
+            this.persons.addAll(persons);
+        }
+        if (reminders != null) {
+            this.reminders.addAll(reminders);
+        }
     }
 
     /**
@@ -38,6 +47,7 @@ class JsonSerializableAddressBook {
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
+        reminders.addAll(source.getReminderList().stream().map(JsonAdaptedReminder::new).collect(Collectors.toList()));
     }
 
     /**
@@ -54,6 +64,15 @@ class JsonSerializableAddressBook {
             }
             addressBook.addPerson(person);
         }
+
+        for (JsonAdaptedReminder jsonAdaptedReminder : reminders) {
+            Reminder reminder = jsonAdaptedReminder.toModelType();
+            if (addressBook.hasReminder(reminder)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_REMINDER);
+            }
+            addressBook.addReminder(reminder);
+        }
+
         return addressBook;
     }
 

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateReminderAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateReminderAddressBook.json
@@ -1,0 +1,35 @@
+{
+  "persons" : [ {
+    "name" : "Alice Pauline",
+    "phone" : "94351253",
+    "email" : "alice@example.com",
+    "address" : "123, Jurong West Ave 6, #08-111",
+    "note" : "",
+    "tags" : [ ]
+  } ],
+  "reminders" : [ {
+    "person" : {
+      "name" : "Alice Pauline",
+      "phone" : "94351253",
+      "email" : "alice@example.com",
+      "address" : "123, Jurong West Ave 6, #08-111",
+      "note" : "",
+      "tags" : [ ]
+    },
+    "date" : "2025-12-01 10:00",
+    "message" : "Duplicate reminder",
+    "isCompleted" : false
+  }, {
+    "person" : {
+      "name" : "Alice Pauline",
+      "phone" : "94351253",
+      "email" : "alice@example.com",
+      "address" : "123, Jurong West Ave 6, #08-111",
+      "note" : "",
+      "tags" : [ ]
+    },
+    "date" : "2025-12-01 10:00",
+    "message" : "Duplicate reminder",
+    "isCompleted" : false
+  } ]
+}

--- a/src/test/data/JsonSerializableAddressBookTest/invalidReminderAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidReminderAddressBook.json
@@ -1,0 +1,23 @@
+{
+  "persons" : [ {
+    "name" : "Alice Pauline",
+    "phone" : "94351253",
+    "email" : "alice@example.com",
+    "address" : "123, Jurong West Ave 6, #08-111",
+    "note" : "",
+    "tags" : [ ]
+  } ],
+  "reminders" : [ {
+    "person" : {
+      "name" : "Alice Pauline",
+      "phone" : "94351253",
+      "email" : "alice@example.com",
+      "address" : "123, Jurong West Ave 6, #08-111",
+      "note" : "",
+      "tags" : [ ]
+    },
+    "date" : "invalid-date-format",
+    "message" : "Test reminder",
+    "isCompleted" : false
+  } ]
+}

--- a/src/test/data/JsonSerializableAddressBookTest/typicalRemindersAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalRemindersAddressBook.json
@@ -1,0 +1,61 @@
+{
+  "persons" : [ {
+    "name" : "Alice Pauline",
+    "phone" : "94351253",
+    "email" : "alice@example.com",
+    "address" : "123, Jurong West Ave 6, #08-111",
+    "note" : "",
+    "tags" : [ "friends" ]
+  }, {
+    "name" : "Benson Meier",
+    "phone" : "98765432",
+    "email" : "johnd@example.com",
+    "address" : "311, Clementi Ave 2, #02-25",
+    "note" : "",
+    "tags" : [ "owesMoney", "friends" ]
+  }, {
+    "name" : "Carl Kurz",
+    "phone" : "95352563",
+    "email" : "heinz@example.com",
+    "address" : "wall street",
+    "note" : "",
+    "tags" : [ ]
+  } ],
+  "reminders" : [ {
+    "person" : {
+      "name" : "Alice Pauline",
+      "phone" : "94351253",
+      "email" : "alice@example.com",
+      "address" : "123, Jurong West Ave 6, #08-111",
+      "note" : "",
+      "tags" : [ "friends" ]
+    },
+    "date" : "2025-12-01 10:00",
+    "message" : "Follow up on project",
+    "isCompleted" : false
+  }, {
+    "person" : {
+      "name" : "Benson Meier",
+      "phone" : "98765432",
+      "email" : "johnd@example.com",
+      "address" : "311, Clementi Ave 2, #02-25",
+      "note" : "",
+      "tags" : [ "owesMoney", "friends" ]
+    },
+    "date" : "2025-11-15 14:30",
+    "message" : "Coffee meeting",
+    "isCompleted" : false
+  }, {
+    "person" : {
+      "name" : "Carl Kurz",
+      "phone" : "95352563",
+      "email" : "heinz@example.com",
+      "address" : "wall street",
+      "note" : "",
+      "tags" : [ ]
+    },
+    "date" : "2025-12-15 09:00",
+    "message" : "Review documents",
+    "isCompleted" : false
+  } ]
+}

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -12,6 +12,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.AddressBook;
 import seedu.address.testutil.TypicalPersons;
+import seedu.address.testutil.TypicalReminders;
 
 public class JsonSerializableAddressBookTest {
 
@@ -19,6 +20,9 @@ public class JsonSerializableAddressBookTest {
     private static final Path TYPICAL_PERSONS_FILE = TEST_DATA_FOLDER.resolve("typicalPersonsAddressBook.json");
     private static final Path INVALID_PERSON_FILE = TEST_DATA_FOLDER.resolve("invalidPersonAddressBook.json");
     private static final Path DUPLICATE_PERSON_FILE = TEST_DATA_FOLDER.resolve("duplicatePersonAddressBook.json");
+    private static final Path TYPICAL_REMINDERS_FILE = TEST_DATA_FOLDER.resolve("typicalRemindersAddressBook.json");
+    private static final Path INVALID_REMINDER_FILE = TEST_DATA_FOLDER.resolve("invalidReminderAddressBook.json");
+    private static final Path DUPLICATE_REMINDER_FILE = TEST_DATA_FOLDER.resolve("duplicateReminderAddressBook.json");
 
     @Test
     public void toModelType_typicalPersonsFile_success() throws Exception {
@@ -41,6 +45,30 @@ public class JsonSerializableAddressBookTest {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_PERSON_FILE,
                 JsonSerializableAddressBook.class).get();
         assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_PERSON,
+                dataFromFile::toModelType);
+    }
+
+    @Test
+    public void toModelType_typicalRemindersFile_success() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_REMINDERS_FILE,
+                JsonSerializableAddressBook.class).get();
+        AddressBook addressBookFromFile = dataFromFile.toModelType();
+        AddressBook typicalRemindersAddressBook = TypicalReminders.getTypicalAddressBookWithReminders();
+        assertEquals(addressBookFromFile, typicalRemindersAddressBook);
+    }
+
+    @Test
+    public void toModelType_invalidReminderFile_throwsIllegalValueException() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(INVALID_REMINDER_FILE,
+                JsonSerializableAddressBook.class).get();
+        assertThrows(IllegalValueException.class, dataFromFile::toModelType);
+    }
+
+    @Test
+    public void toModelType_duplicateReminders_throwsIllegalValueException() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_REMINDER_FILE,
+                JsonSerializableAddressBook.class).get();
+        assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_REMINDER,
                 dataFromFile::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/ReminderBuilder.java
+++ b/src/test/java/seedu/address/testutil/ReminderBuilder.java
@@ -1,0 +1,76 @@
+package seedu.address.testutil;
+
+import seedu.address.model.person.Person;
+import seedu.address.model.reminder.Date;
+import seedu.address.model.reminder.Message;
+import seedu.address.model.reminder.Reminder;
+
+/**
+ * A utility class to help with building Reminder objects.
+ */
+public class ReminderBuilder {
+
+    public static final String DEFAULT_DATE = "2025-12-01 10:00";
+    public static final String DEFAULT_MESSAGE = "Default reminder message";
+
+    private Person person;
+    private Date date;
+    private Message message;
+    private boolean isCompleted;
+
+    /**
+     * Creates a {@code ReminderBuilder} with the default details.
+     */
+    public ReminderBuilder() {
+        person = new PersonBuilder().build();
+        date = new Date(DEFAULT_DATE);
+        message = new Message(DEFAULT_MESSAGE);
+        isCompleted = false;
+    }
+
+    /**
+     * Initializes the ReminderBuilder with the data of {@code reminderToCopy}.
+     */
+    public ReminderBuilder(Reminder reminderToCopy) {
+        person = reminderToCopy.getPerson();
+        date = reminderToCopy.getDate();
+        message = reminderToCopy.getMessage();
+        isCompleted = reminderToCopy.isCompleted();
+    }
+
+    /**
+     * Sets the {@code Person} of the {@code Reminder} that we are building.
+     */
+    public ReminderBuilder withPerson(Person person) {
+        this.person = person;
+        return this;
+    }
+
+    /**
+     * Sets the {@code Date} of the {@code Reminder} that we are building.
+     */
+    public ReminderBuilder withDate(String date) {
+        this.date = new Date(date);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Message} of the {@code Reminder} that we are building.
+     */
+    public ReminderBuilder withMessage(String message) {
+        this.message = new Message(message);
+        return this;
+    }
+
+    /**
+     * Sets the {@code isCompleted} status of the {@code Reminder} that we are building.
+     */
+    public ReminderBuilder withCompleted(boolean isCompleted) {
+        this.isCompleted = isCompleted;
+        return this;
+    }
+
+    public Reminder build() {
+        return new Reminder(person, date, message, isCompleted);
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalReminders.java
+++ b/src/test/java/seedu/address/testutil/TypicalReminders.java
@@ -1,0 +1,54 @@
+package seedu.address.testutil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.reminder.Reminder;
+
+/**
+ * A utility class containing a list of {@code Reminder} objects to be used in tests.
+ */
+public class TypicalReminders {
+
+    public static final Reminder ALICE_REMINDER = new ReminderBuilder()
+            .withPerson(TypicalPersons.ALICE)
+            .withDate("2025-12-01 10:00")
+            .withMessage("Follow up on project")
+            .build();
+
+    public static final Reminder BENSON_REMINDER = new ReminderBuilder()
+            .withPerson(TypicalPersons.BENSON)
+            .withDate("2025-11-15 14:30")
+            .withMessage("Coffee meeting")
+            .build();
+
+    public static final Reminder CARL_REMINDER = new ReminderBuilder()
+            .withPerson(TypicalPersons.CARL)
+            .withDate("2025-12-15 09:00")
+            .withMessage("Review documents")
+            .build();
+
+    private TypicalReminders() {} // prevents instantiation
+
+    /**
+     * Returns an {@code AddressBook} with the persons who have reminders and their reminders.
+     */
+    public static AddressBook getTypicalAddressBookWithReminders() {
+        AddressBook ab = new AddressBook();
+        // Only add the persons that have reminders
+        ab.addPerson(TypicalPersons.ALICE);
+        ab.addPerson(TypicalPersons.BENSON);
+        ab.addPerson(TypicalPersons.CARL);
+
+        for (Reminder reminder : getTypicalReminders()) {
+            ab.addReminder(reminder);
+        }
+        return ab;
+    }
+
+    public static List<Reminder> getTypicalReminders() {
+        return new ArrayList<>(Arrays.asList(ALICE_REMINDER, BENSON_REMINDER, CARL_REMINDER));
+    }
+}


### PR DESCRIPTION
This pull request adds support for serializing and deserializing `Reminder` objects to and from JSON in the address book application. It introduces a new `JsonAdaptedReminder` class for Jackson compatibility, updates the storage logic to handle reminders, and adds comprehensive tests for reminder serialization, including typical, invalid, and duplicate reminders. Additionally, utility classes and test data are provided to facilitate testing.

**Reminder Serialization Support:**

* Added the `JsonAdaptedReminder` class to handle Jackson serialization/deserialization for `Reminder` objects, including validation and conversion logic.
* Updated `JsonSerializableAddressBook` to support storing and loading reminders:
  - Added a `reminders` field and appropriate constructor logic.
  - Ensured reminders are converted to/from model objects and checked for duplicates during deserialization.
  - Added a duplicate reminder error message. [[1]](diffhunk://#diff-99411d32b692b62fcae4b979a9996569520bc4349f8b900d2fa1b275333e7ee9R15) [[2]](diffhunk://#diff-99411d32b692b62fcae4b979a9996569520bc4349f8b900d2fa1b275333e7ee9R24-R41) [[3]](diffhunk://#diff-99411d32b692b62fcae4b979a9996569520bc4349f8b900d2fa1b275333e7ee9R50) [[4]](diffhunk://#diff-99411d32b692b62fcae4b979a9996569520bc4349f8b900d2fa1b275333e7ee9R67-R75)

**Testing and Utilities:**

* Added test data files for typical reminders, invalid reminders, and duplicate reminders in JSON format. [[1]](diffhunk://#diff-d0959128f3577eb1bdb88f10ad08e4b2591cd8bdc6e72b9898cab296fb5f61dfR1-R61) [[2]](diffhunk://#diff-0a4329f793557c0418689669afda534b78e0781bf30f5dbc9f4fc819493353faR1-R23) [[3]](diffhunk://#diff-1ae765878a12e2449efdc40f95cdf2331c9b32db6a07d56bbbcc9b2a7dd99560R1-R35)
* Introduced `ReminderBuilder` and `TypicalReminders` utility classes to streamline test creation and provide standard reminder objects for tests. [[1]](diffhunk://#diff-19d87256537cc87c8c2cce012288e4c2801efdce98d584093fe12ee0ffcc0eb7R1-R76) [[2]](diffhunk://#diff-3b25c0ebc8bc61d4a8fd6a11ef6091a17d670e544a3c043fffe99a1d98d9c17bR1-R54)
* Extended `JsonSerializableAddressBookTest` to verify correct (de)serialization of reminders, and to assert proper error handling for invalid and duplicate reminders. [[1]](diffhunk://#diff-bde292b14109f875c7abcd8af61725e9487d1ced36eafb1a2fc355fc3ea6d131R15-R25) [[2]](diffhunk://#diff-bde292b14109f875c7abcd8af61725e9487d1ced36eafb1a2fc355fc3ea6d131R51-R74)

**Reminder Model Improvements:**

* Updated the `Reminder` model's `equals` and `hashCode` methods to include the `isCompleted` field, ensuring correct equality and hashing behavior.

**Other Minor Changes:**

* Modified the `Date.isUpcoming()` method to simplify its logic by removing the seven-day constraint, now only checking if the date is not in the past.
* 
Closes #104 