### PR TITLE
Fix mark command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ReminderMarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ReminderMarkCommand.java
@@ -51,7 +51,8 @@ public class ReminderMarkCommand extends ReminderCommand {
                 throw new CommandException(Messages.MESSAGE_INVALID_REMINDER_DISPLAYED_INDEX);
             }
             Reminder reminder = lastShownList.get(targetIndex.getZeroBased());
-            reminder.markAsCompleted();
+            model.deleteReminder(reminder);
+            model.addReminder(reminder.markAsCompleted());
             model.updateFilteredReminderList(PREDICATE_SHOW_UPCOMING_REMINDERS);
             markedReminders.append(Messages.format(reminder)).append("\n");
         }


### PR DESCRIPTION
This pull request updates the way reminders are marked as completed in the `ReminderMarkCommand`. Instead of mutating the existing reminder, the code now deletes the old reminder and adds a new, completed version to the model.

Reminder completion logic update:

* Changed the reminder completion process to remove the existing reminder and add a new, completed reminder, ensuring immutability and consistency in the model (`ReminderMarkCommand.java`).

Closes #106 