### PR TITLE
Fix reminder when deleted person

### DIFF
--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -127,4 +127,11 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredReminderList(Predicate<Reminder> predicate);
+
+    /**
+     * Returns a list of reminders associated with the given person.
+     * @param person The person to get reminders for.
+     * @return A list of reminders for the specified person.
+     */
+    java.util.List<Reminder> getRemindersByPerson(Person person);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -181,6 +181,14 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public java.util.List<Reminder> getRemindersByPerson(Person person) {
+        requireNonNull(person);
+        return filteredReminders.stream()
+                .filter(reminder -> reminder.getPerson().equals(person))
+                .collect(java.util.stream.Collectors.toList());
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -194,6 +194,11 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        @Override
+        public java.util.List<Reminder> getRemindersByPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
     }
 
     /**


### PR DESCRIPTION
This pull request enhances the `DeleteCommand` so that when a person is deleted, any reminders associated with that person are also deleted. The user is now notified of how many reminders were removed.

Closes #130 