### PR TITLE
Fix reminder list

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -38,10 +39,30 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         filteredReminders = new FilteredList<>(this.addressBook.getReminderList());
+
+        cleanUpOrphanedReminders();
+        updateFilteredReminderList(PREDICATE_SHOW_UPCOMING_REMINDERS);
     }
 
     public ModelManager() {
         this(new AddressBook(), new UserPrefs());
+    }
+
+    /**
+     * Removes reminders that point to persons that no longer exist in the address book.
+     * This handles cases where reminders were left behind when persons were deleted.
+     */
+    private void cleanUpOrphanedReminders() {
+        ObservableList<Person> persons = addressBook.getPersonList();
+        ObservableList<Reminder> reminders = addressBook.getReminderList();
+
+        List<Reminder> orphanedReminders = reminders.stream()
+                .filter(reminder -> !persons.contains(reminder.getPerson()))
+                .collect(java.util.stream.Collectors.toList());
+
+        for (Reminder orphanedReminder : orphanedReminders) {
+            addressBook.removeReminder(orphanedReminder);
+        }
     }
 
     //=========== UserPrefs ==================================================================================


### PR DESCRIPTION
Closes #137 
This pull request introduces a data integrity improvement to the `ModelManager` class by ensuring that reminders referencing deleted persons are automatically cleaned up.

Additionally, it set the predicate to PREDICATE_SHOW_UPCOMING_REMINDERS to avoid showing completed/past reminders when starting the app.